### PR TITLE
Clone field using before contributing to class.

### DIFF
--- a/modelmixins/__init__.py
+++ b/modelmixins/__init__.py
@@ -1,6 +1,8 @@
 """
 Mixin support for django models
 """
+import copy
+
 from django.db import models
 from django.db.models.signals import class_prepared
 from django.dispatch import receiver
@@ -25,7 +27,7 @@ class ModelMixin(object):
                 fields[name] = attr
 
         for (key, field) in list(fields.items()):
-            field.contribute_to_class(target, key)
+            copy.deepcopy(field).contribute_to_class(target, key)
 
 
 @receiver(class_prepared)


### PR DESCRIPTION
Make sure to clone the field before contributing in to the class. This would remove the error where a ManyToManyField's automatically generated "through" model doesn't have the necessary foreign keys for both models linking to the same model. See #5. This commit does not solve the problem when a custom through model is used.
